### PR TITLE
Base Character에 죽음 메소드 추가

### DIFF
--- a/Source/UnrealPortfolio/Character/UPCharacter.cpp
+++ b/Source/UnrealPortfolio/Character/UPCharacter.cpp
@@ -51,3 +51,8 @@ void AUPCharacter::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);
 }
+
+void AUPCharacter::SetDead()
+{
+}
+

--- a/Source/UnrealPortfolio/Character/UPCharacter.h
+++ b/Source/UnrealPortfolio/Character/UPCharacter.h
@@ -28,4 +28,7 @@ private:
 	/** Camera boom positioning the camera above the character */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
 	class USpringArmComponent* CameraBoom;
+
+protected:
+	virtual void SetDead();
 };


### PR DESCRIPTION
## 기본 Character 에 통합 메소드 추가

피격과 공격, 이동, 죽음 총 3개를 구현 및 테스트를 진행하려 했으나
GAS를 사용하는 시점에서 피격과 공격은 GA에서 진행하고
Behavior Tree 를 사용하는 시점에서 적의 이동을 구현하기 때문에
공통적으로 포함되는 메소드는 추후 다시 확인해 봐야 할것으로 추측되어

해당 작업을 여기서 마무리함.