### PR TITLE
NPC 상호작용 알림 위젯

### DIFF
--- a/Source/UnrealPortfolio/Character/UPNPCCharacter.cpp
+++ b/Source/UnrealPortfolio/Character/UPNPCCharacter.cpp
@@ -3,9 +3,8 @@
 
 #include "Character/UPNPCCharacter.h"
 #include "defines/UPCollision.h"
-#include "Animation/AnimClassData.h"
 #include "Components/CapsuleComponent.h"
-#include "GameFramework/CharacterMovementComponent.h"
+#include "Components/WidgetComponent.h"
 
 // Sets default values
 AUPNPCCharacter::AUPNPCCharacter()
@@ -17,7 +16,7 @@ AUPNPCCharacter::AUPNPCCharacter()
 	// Mesh
 	GetMesh()->SetRelativeLocationAndRotation(FVector(0.0f, 0.0f, -100.0f), FRotator(0.0f, -90.0f, 0.0f));
 	GetMesh()->SetAnimationMode(EAnimationMode::AnimationBlueprint);
-	GetMesh()->SetCollisionProfileName(TEXT("Pawn"));
+	GetMesh()->SetCollisionProfileName(CPROFILE_PAWN);
 
 	static ConstructorHelpers::FObjectFinder<USkeletalMesh> CharacterMeshRef(TEXT("/Script/Engine.SkeletalMesh'/Game/OtherCharacterPack/Mesh/Dwarf_Mesh.Dwarf_Mesh'"));
 	if (CharacterMeshRef.Object)
@@ -32,6 +31,17 @@ AUPNPCCharacter::AUPNPCCharacter()
 		GetMesh()->SetAnimInstanceClass(CharacterAnimRef.Class);
 	}
 
+	InterActionCompo = CreateDefaultSubobject<UWidgetComponent>(TEXT("InterActionCompo"));
+	InterActionCompo->SetupAttachment(GetMesh());
+	
+	static ConstructorHelpers::FClassFinder<UUserWidget> InterActionClassRef(TEXT("/Game/UI/WBP_InterAction.WBP_InterAction_C"));
+	 if(InterActionClassRef.Class)
+	 {
+	 	InterActionCompo->SetWidgetClass(InterActionClassRef.Class);
+	 	InterActionCompo->SetWidgetSpace(EWidgetSpace::World);
+	 	InterActionCompo->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	 }
+
 	TakeUiActions.Add(FTakeWidgetDelegateWrapper(FOnShowNPCWidgetDelegate::CreateUObject(this,&AUPNPCCharacter::ShowWeaponShopWidget)));
 	TakeUiActions.Add(FTakeWidgetDelegateWrapper(FOnShowNPCWidgetDelegate::CreateUObject(this,&AUPNPCCharacter::ShowItemShopWidget)));
 	TakeUiActions.Add(FTakeWidgetDelegateWrapper(FOnShowNPCWidgetDelegate::CreateUObject(this,&AUPNPCCharacter::ShowRaiderSelector)));
@@ -45,8 +55,9 @@ void AUPNPCCharacter::TakeNPCWidget()
 void AUPNPCCharacter::BeginPlay()
 {
 	Super::BeginPlay();
-	TakeNPCWidget();
-	
+	InterActionCompo->GetWidget()->AddToViewport();
+	HideInterAction();
+
 }
 
 void AUPNPCCharacter::ShowWeaponShopWidget()
@@ -62,4 +73,20 @@ void AUPNPCCharacter::ShowItemShopWidget()
 void AUPNPCCharacter::ShowRaiderSelector()
 {
 	UE_LOG(LogTemp,Log,TEXT("ShowRaiderSelector"));
+}
+
+void AUPNPCCharacter::ShowInterAction()
+{
+	if(InterActionCompo)
+	{
+		InterActionCompo->GetWidget()->SetVisibility(ESlateVisibility::Visible);	
+	}
+}
+
+void AUPNPCCharacter::HideInterAction()
+{
+	if(InterActionCompo)
+	{
+		InterActionCompo->GetWidget()->SetVisibility(ESlateVisibility::Hidden);		
+	}
 }

--- a/Source/UnrealPortfolio/Character/UPNPCCharacter.h
+++ b/Source/UnrealPortfolio/Character/UPNPCCharacter.h
@@ -49,5 +49,14 @@ protected:
 	void ShowWeaponShopWidget();
 	void ShowItemShopWidget();
 	void ShowRaiderSelector();
+
+protected:
+	UPROPERTY(VisibleAnywhere, Category = UI)
+	TObjectPtr<class UWidgetComponent> InterActionCompo;
+public:
+	UFUNCTION(BlueprintCallable)
+	void ShowInterAction();
+	UFUNCTION(BlueprintCallable)
+	void HideInterAction();
 	
 };

--- a/Source/UnrealPortfolio/Gimmick/UPNPCDetectorSceneComponent.cpp
+++ b/Source/UnrealPortfolio/Gimmick/UPNPCDetectorSceneComponent.cpp
@@ -20,7 +20,6 @@ UUPNPCDetectorSceneComponent::UUPNPCDetectorSceneComponent()
 	BoxComp->SetCollisionProfileName(CPROFILE_NPC);
 	BoxComp->OnComponentBeginOverlap.AddDynamic(this,&UUPNPCDetectorSceneComponent::OnOverlapBegin);
 	BoxComp->OnComponentEndOverlap.AddDynamic(this,&UUPNPCDetectorSceneComponent::OnOverlapEnd);
-	BoxComp->SetupAttachment(this);
 }
 
 void UUPNPCDetectorSceneComponent::Action() const
@@ -34,12 +33,13 @@ void UUPNPCDetectorSceneComponent::Action() const
 void UUPNPCDetectorSceneComponent::OnOverlapBegin(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
 	UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepHitResult)
 {
-	if(OtherActor != nullptr)
+	const auto Character = Cast<IUPUINpcInterface>(OtherActor);
+	if(Character == nullptr)
 	{
-		UE_LOG(LogTemp,Log,TEXT("NPC Get"));
-		UINPC =  Cast<IUPUINpcInterface>(OtherActor);
+		return;
 	}
-		
+	UINPC = Character;
+	UINPC->ShowInterAction();
 }
 
 void UUPNPCDetectorSceneComponent::OnOverlapEnd(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,
@@ -50,6 +50,7 @@ void UUPNPCDetectorSceneComponent::OnOverlapEnd(UPrimitiveComponent* OverlappedC
 
 	if(ExistActor == UINPC)
 	{
+		UINPC->HideInterAction();
 		UINPC = nullptr;
 	}
 }
@@ -57,5 +58,5 @@ void UUPNPCDetectorSceneComponent::OnOverlapEnd(UPrimitiveComponent* OverlappedC
 void UUPNPCDetectorSceneComponent::SetParent(USceneComponent* InParent)
 {
 	this->SetupAttachment(InParent);
-	BoxComp->SetupAttachment(InParent);
+	BoxComp->SetupAttachment(InParent);	
 }

--- a/Source/UnrealPortfolio/Interface/UPUINpcInterface.h
+++ b/Source/UnrealPortfolio/Interface/UPUINpcInterface.h
@@ -21,6 +21,8 @@ class UNREALPORTFOLIO_API IUPUINpcInterface
 	GENERATED_BODY()
 public:
 	virtual  void TakeNPCWidget() =0;
+	virtual  void ShowInterAction() =0;
+	virtual  void HideInterAction() =0;
 
 	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:

--- a/Source/UnrealPortfolio/UI/UPUserWidget.cpp
+++ b/Source/UnrealPortfolio/UI/UPUserWidget.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "UI/UPUserWidget.h"
+

--- a/Source/UnrealPortfolio/UI/UPUserWidget.h
+++ b/Source/UnrealPortfolio/UI/UPUserWidget.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "UPUserWidget.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class UNREALPORTFOLIO_API UUPUserWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+};


### PR DESCRIPTION
# NPC 상호작용 알림 위젯

기능 NPC가 탐지 범위 내에 확인되면 위젯을 활성화한다 반대로 탐지된 타겟이 없다면 비활성화한다

추가된 위젯 WBP_InterAction
![스크린샷 2024-04-03 오전 5 23 43](https://github.com/727207e/UnrealPortfolio/assets/49323810/a2f2d677-32e6-4186-b269-c611be2f143d)
추가된 클래스
UPUserWidget 생성이유 언리얼 제공 클래스와 프로젝트 정의 클래스간의 구분 WBP_InterAction 위젯도  UPUserWidget을 상속받는다

테스트 영상

https://github.com/727207e/UnrealPortfolio/assets/49323810/5138bc8c-f479-4cd6-9696-6952cefe0fcf

