### PR TITLE
다중 GA 제작 문제 수정

### DIFF
--- a/Source/UnrealPortfolio/GAS/GA/GA_AttackHitCheck.cpp
+++ b/Source/UnrealPortfolio/GAS/GA/GA_AttackHitCheck.cpp
@@ -13,7 +13,7 @@
 
 UGA_AttackHitCheck::UGA_AttackHitCheck(): CurrentLevel(0)
 {
-	InstancingPolicy = EGameplayAbilityInstancingPolicy::InstancedPerActor;
+	InstancingPolicy = EGameplayAbilityInstancingPolicy::InstancedPerExecution;
 
 	CurrentTA = AGATA_Trace::StaticClass();
 }


### PR DESCRIPTION
인스턴싱 관련 정책 문제

https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/GameplayAbilitySystem/GameplayAbility/

GA가 이미 실행중인경우 인스턴싱이 되어있어서 재활용하는 문제가 있었음.
따라서, 이미 사용중인 GA가 있으면 다음 GA는 호출되지 않았던 문제.

아래 영상은 이를 각 실행마다 인스턴싱을 진행하여 같은 GA를 여러번 호출하게 해주는 것으로 해결함.

https://github.com/727207e/UnrealPortfolio/assets/54798151/b9481127-5a17-4469-a3a1-661a7a39283c

